### PR TITLE
added instructions for Ubuntu installation

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -55,6 +55,23 @@ pip install -r requirements.txt
 
 ```
 
+Example set of commands for installation on Linux [Ubuntu]:
+```
+conda create -n Garments python=3.9
+conda activate Garments
+
+conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
+# for pytorch-cuda, insert cuda version that is listed under nvidia-smi
+# in this case, the cuda version is 12.1
+
+conda install pyg -c pyg
+conda install pytorch-cluster -c pyg
+
+conda install -c conda-forge igl=2.2.1 svgwrite svglib wandb
+
+pip install sparsemax entmax
+```
+
 Development was done on _Windows 10\11_ and Ubuntu. If running on other OS ends up with errors, please, raise an issue!
 
 **Notes on errors with PIL.Image**


### PR DESCRIPTION
Installation with the instructions on the installation page proved a bit frustrating, as ```torch-sparse, torch-geometric``` in the form as listed in the installation guide led to segmentation faults with the newest cuda version. 

A new installation path for these is available from the new ```pytorch-geometric``` site, [here](https://pytorch-geometric.readthedocs.io/en/latest/install/installation.html). 

This worked smoothly for ubuntu. 